### PR TITLE
Fix metadata path when moving uploaded files

### DIFF
--- a/3DPrintSystem/app/routes/dashboard.py
+++ b/3DPrintSystem/app/routes/dashboard.py
@@ -282,7 +282,7 @@ def approve_job(job_id):
         
         # Move file from Uploaded to Pending directory
         try:
-            new_file_path = _move_file_between_status_dirs(
+            new_file_path, new_metadata_path = _move_file_between_status_dirs(
                 job.file_path, 'Uploaded', 'Pending'
             )
         except Exception as e:
@@ -299,6 +299,8 @@ def approve_job(job_id):
         job.material = material or job.material
         job.cost_usd = calculated_cost
         job.file_path = new_file_path
+        if new_metadata_path:
+            job.metadata_path = new_metadata_path
         job.last_updated_by = 'staff'
         job.staff_viewed_at = datetime.utcnow()  # Mark as reviewed during approval
         if notes:
@@ -451,8 +453,9 @@ def _move_file_between_status_dirs(current_path, from_status, to_status):
     # Also move metadata file if it exists
     metadata_filename = os.path.splitext(filename)[0] + '.metadata.json'
     current_metadata_path = os.path.join(os.path.dirname(current_path), metadata_filename)
+    new_metadata_path = None
     if os.path.exists(current_metadata_path):
         new_metadata_path = os.path.join(target_dir, metadata_filename)
         os.rename(current_metadata_path, new_metadata_path)
-    
-    return new_path
+
+    return new_path, new_metadata_path

--- a/tests/test_file_move.py
+++ b/tests/test_file_move.py
@@ -1,0 +1,35 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '3DPrintSystem'))
+from app import create_app
+from app.routes.dashboard import _move_file_between_status_dirs
+
+
+def test_move_file_updates_metadata_path(tmp_path):
+    os.environ['SECRET_KEY'] = 'test'
+    os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+    os.environ['STAFF_PASSWORD'] = 'pass'
+
+    app = create_app()
+    app.config['APP_STORAGE_ROOT'] = str(tmp_path)
+    app.config['UPLOAD_FOLDER'] = str(tmp_path / 'Uploaded')
+
+    upload_dir = Path(app.config['UPLOAD_FOLDER'])
+    upload_dir.mkdir(parents=True)
+    pending_dir = Path(app.config['APP_STORAGE_ROOT']) / 'Pending'
+    pending_dir.mkdir()
+
+    test_file = upload_dir / 'model.stl'
+    test_file.write_text('data')
+    meta_file = upload_dir / 'model.metadata.json'
+    meta_file.write_text('{}')
+
+    with app.app_context():
+        new_file, new_meta = _move_file_between_status_dirs(str(test_file), 'Uploaded', 'Pending')
+
+    assert Path(new_file).exists()
+    assert Path(new_meta).exists()
+    assert Path(new_file).parent == pending_dir
+    assert Path(new_meta).parent == pending_dir


### PR DESCRIPTION
## Summary
- ensure metadata path is updated when moving files between status folders
- test `_move_file_between_status_dirs` returns new metadata path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pytest tests/test_file_move.py -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_683fa1d4be40832696ab1cd088e5ff0d